### PR TITLE
fix: the build-all in build-all.js

### DIFF
--- a/scripts/build-all.js
+++ b/scripts/build-all.js
@@ -8,6 +8,9 @@ const { ROOT, listSubmissions } = require('./lib/repository');
 
 const outputArg = process.argv.includes('--output') ? process.argv[process.argv.indexOf('--output') + 1] : 'site/papers';
 const outputRoot = path.resolve(ROOT, outputArg);
+if (outputRoot !== ROOT && !outputRoot.startsWith(ROOT + path.sep)) {
+  throw new Error(`--output path must be within the repository root: ${outputRoot}`);
+}
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 function valuesFor(flag) {


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/build-all.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/build-all.js:9` |
| **Assessment** | Likely exploitable |

**Description**: The build-all.js script accepts an --output argument from command-line without validating that the resolved path remains within the intended directory. An attacker can supply a path that escapes the intended output directory, allowing unauthorized file access.

## Evidence

**Exploitation scenario**: Execute: npm run build:paper -- --output /etc/passwd or --output ../../../../etc/passwd.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `scripts/build-all.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
