### PR TITLE
Fix Unlimited OCR image paths for subpath deployment

### DIFF
--- a/html_output/unlimited_ocr_works/src/data/tutorial.ts
+++ b/html_output/unlimited_ocr_works/src/data/tutorial.ts
@@ -85,7 +85,7 @@ export const tutorial: TutorialData = {
           title: '改了哪里：保留三段底座，只替换解码器注意力',
           desc: '选择组件，对照论文 Figure 2 的继承路径与 R-SWA 改动。',
           componentId: 'unlimited-interactive',
-          figure: '/images/paper-fig2-architecture-animated.gif',
+          figure: './images/paper-fig2-architecture-animated.gif',
         },
       ],
       insight: '底座压缩输入；R-SWA 控制长输出成本。',
@@ -113,7 +113,7 @@ export const tutorial: TutorialData = {
           title: '第一步，划定可见范围：P 全局，Dₙ(t) 局部',
           desc: '调节查询位置 t 和示意窗口 n，对照论文式（1）—（2）；论文默认 n=128。',
           componentId: 'unlimited-interactive',
-          figure: '/images/paper-fig1-rswa-animated.gif',
+          figure: './images/paper-fig1-rswa-animated.gif',
         },
         {
           kind: 'module',
@@ -186,7 +186,7 @@ export const tutorial: TutorialData = {
       analogy: {
         title: '两类证据，回答同一个效率问题',
         text: 'Table 4：prefill=10、理想并发。',
-        figure: '/images/paper-fig3-kernel-animated.gif',
+        figure: './images/paper-fig3-kernel-animated.gif',
       },
       modules: [
         {


### PR DESCRIPTION
## 问题

Unlimited OCR Works 教程已部署在 `/PaperSkill/papers/unlimited_ocr_works/` 子路径下，但三个论文 GIF 使用 `/images/...` 根路径，浏览器因此请求 `https://reducttech.github.io/images/...` 并得到 404。

图片文件本身已正确提交，正确的部署位置为 `/PaperSkill/papers/unlimited_ocr_works/images/...`。

## 修复

将三个图片引用从根路径改为相对于教程入口的路径：

```text
/images/...  →  ./images/...
```

涉及 Figure 1、Figure 2 和 Figure 3 的动画 GIF，不修改教程内容或其他作品。

## 验证

- 生成项目 `npm run build`：通过
- 仓库 `npm run validate`：通过
- `npm run catalog`：通过，无 catalog 差异
- `npm run validate:pr -- main`：通过，仅 1 个文件
- `npm run build:paper -- unlimited_ocr_works`：通过
- 模拟 `/papers/unlimited_ocr_works/` 子路径托管：首页及三个 GIF 均返回 HTTP 200
