### PR TITLE
Fix PE-Field 4D subpath images and generation status text

### DIFF
--- a/html_output/pe_field_4d_video_generation_models_as_canvas/src/data/tutorial.ts
+++ b/html_output/pe_field_4d_video_generation_models_as_canvas/src/data/tutorial.ts
@@ -154,7 +154,7 @@ export const tutorial: TutorialData = {
           title: "总体评估",
           desc: "",
           componentId: "metric-race",
-          figure: "/images/pe-field-comparison.png",
+          figure: "./images/pe-field-comparison.png",
         },
         {
           kind: "module",
@@ -162,7 +162,7 @@ export const tutorial: TutorialData = {
           title: "消融实验",
           desc: "分别移除深度消歧和时间消歧，在同一DAVIS评测协议下观察几何一致性与相机精度的变化。",
           componentId: "ablation-lab",
-          figure: "/images/pe-field-ablation.png",
+          figure: "./images/pe-field-ablation.png",
         },
       ],
       insight: "",

--- a/html_output/pe_field_4d_video_generation_models_as_canvas/src/modules/image-viewpoint-demo.tsx
+++ b/html_output/pe_field_4d_video_generation_models_as_canvas/src/modules/image-viewpoint-demo.tsx
@@ -114,9 +114,6 @@ export const ImageViewpointDemo: React.FC<WidgetProps> = () => {
           <button type="button" onClick={generate} disabled={status === 'generating'}>
             {status === 'generating' ? '生成中…' : status === 'done' ? '重新生成' : '生成目标视角'}
           </button>
-          {status === 'done' ? (
-            <span aria-live="polite">已从正面参考图像生成{formatAngle(angle)}目标视角。</span>
-          ) : null}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 问题

PE-Field 4D 教程部署在
`/PaperSkill/papers/pe_field_4d_video_generation_models_as_canvas/`
子路径下，但第五章两张论文图片使用 `/images/...` 根路径，浏览器因此请求
`https://reducttech.github.io/images/...` 并得到 404。

图片文件本身已正确提交，正确部署位置为
`/PaperSkill/papers/pe_field_4d_video_generation_models_as_canvas/images/...`。

此外，第一章每次生成目标视角后会显示重复的角度提示文字。

## 修复

将第五章两张图片引用改为相对于教程入口的路径：

```text
/images/...  →  ./images/...
```

涉及“总体评估”和“消融实验”图片。

同时删除第一章生成完成后的提示文字，保留生成按钮、状态和目标视角结果不变。不修改论文内容、实验数据或其他作品。

## 验证

- 生成项目 `npm run build`：通过
- 仓库 `npm run validate`：通过
- `npm run catalog:check`：通过，无 catalog 差异
- `npm run validate:pr -- main`：通过，仅修改本论文目录中的 2 个文件
- `npm run build:paper -- pe_field_4d_video_generation_models_as_canvas`：通过
- 模拟 `/papers/pe_field_4d_video_generation_models_as_canvas/` 子路径托管：入口及两张图片均返回 HTTP 200
- 构建产物中已无根路径图片引用和生成后的角度提示文字
