### PR TITLE
fix: use relative rollout video paths

### DIFF
--- a/html_output/vla_foundry_a_unified_framework_for_training_vision_language_action_models/src/modules/task_rollouts.tsx
+++ b/html_output/vla_foundry_a_unified_framework_for_training_vision_language_action_models/src/modules/task_rollouts.tsx
@@ -13,20 +13,20 @@ const tasks: Record<TaskKey, {
   place_cup: {
     title: '将杯子放到杯垫旁',
     category: '精细放置',
-    success: '/videos/vla_foundry/place_cup_success.mp4',
-    failure: '/videos/vla_foundry/place_cup_failure.mp4'
+    success: 'videos/vla_foundry/place_cup_success.mp4',
+    failure: 'videos/vla_foundry/place_cup_failure.mp4'
   },
   push_coaster: {
     title: '把杯垫推到桌面中心',
     category: '非抓取推送',
-    success: '/videos/vla_foundry/push_coaster_success.mp4',
-    failure: '/videos/vla_foundry/push_coaster_failure.mp4'
+    success: 'videos/vla_foundry/push_coaster_success.mp4',
+    failure: 'videos/vla_foundry/push_coaster_failure.mp4'
   },
   turn_cup: {
     title: '把杯子翻转',
     category: '姿态变化',
-    success: '/videos/vla_foundry/turn_cup_success.mp4',
-    failure: '/videos/vla_foundry/turn_cup_failure.mp4'
+    success: 'videos/vla_foundry/turn_cup_success.mp4',
+    failure: 'videos/vla_foundry/turn_cup_failure.mp4'
   }
 };
 


### PR DESCRIPTION
 注:由于刚才成功在"https://reducttech.github.io/PaperSkill/#search"界面接收了我的项目，但是由于其中所用到的"视频路径"在完成的时候用的是绝对路径，导致视频无法正常显示，现已修改路径，成功解决。因此修复。
 
 修复 VLA Foundry 教程 5.2 节 rollout 视频在 GitHub Pages 子路径部署下无法加载的问题。

  原因是视频地址原先使用 `/videos/...` 站点根路径，发布后会请求到 `https://reducttech.github.io/videos/...`。改为 `videos/...` 相对路径后，会正确指向当前论
  文页面目录下的视频资源。

  已运行：
  - npm run validate
  - npm run catalog:check
  - npm run validate:pr -- main
  - npm run build:paper -- vla_foundry_a_unified_framework_for_training_vision_language_action_models

  验证结果：validate、catalog:check、validate:pr、build:paper 都通过了。实际 PR 应该只显示这一个文件的 6 行路径修复。
  
  谢谢学长学姐的批改工作，辛苦了。