### PR TITLE
Fix ERNIE-Image tutorial image paths

### DIFF
--- a/html_output/ernie_image_technical_report/src/modules/ch10-results.tsx
+++ b/html_output/ernie_image_technical_report/src/modules/ch10-results.tsx
@@ -85,19 +85,19 @@ const RESULT_SETS: Record<Protocol, ResultSet> = {
 const QUALITATIVE_FIGURES: Record<QualitativeFigure, { label: string; src: string; alt: string; caption: string }> = {
   photo: {
     label: '人像摄影',
-    src: '/images/result-photo.png',
+    src: `${import.meta.env.BASE_URL}images/result-photo.png`,
     alt: '论文中的人像摄影生成结果对比',
     caption: '人像摄影对比：比较面部细节、皮肤质感、姿态与整体真实感。',
   },
   instruction: {
     label: '复杂指令',
-    src: '/images/result-instruction.png',
+    src: `${import.meta.env.BASE_URL}images/result-instruction.png`,
     alt: '论文中的复杂指令遵循结果对比',
     caption: '复杂指令对比：九个角色需要同时满足动作、服装与对应文字要求。',
   },
   text: {
     label: '中文文字',
-    src: '/images/result-text.png',
+    src: `${import.meta.env.BASE_URL}images/result-text.png`,
     alt: '论文中的中文文字渲染结果对比',
     caption: '中文文字对比：观察标题、配料、步骤和页面布局是否准确、完整。',
   },

--- a/html_output/ernie_image_technical_report/src/modules/ch2-representation.tsx
+++ b/html_output/ernie_image_technical_report/src/modules/ch2-representation.tsx
@@ -56,7 +56,7 @@ export const Ch2RepresentationWidget: React.FC<WidgetProps> = () => {
       <figure className="architecture-figure">
         <img
           className="paper-original-figure"
-          src="/images/ernie-image-architecture.png"
+          src={`${import.meta.env.BASE_URL}images/ernie-image-architecture.png`}
           alt="根据论文文字重建的 ERNIE-Image 高层架构：提示增强器与文本编码器形成文字条件，VAE 潜空间与文字条件汇入 8B 单流 DiT，Aes 是独立的数据筛选与审美评估侧路。"
         />
 

--- a/html_output/ernie_image_technical_report/src/modules/ch5-pe.tsx
+++ b/html_output/ernie_image_technical_report/src/modules/ch5-pe.tsx
@@ -23,19 +23,19 @@ const MODES: Record<PeMode, { label: string; color: string }> = {
 
 const IMAGES: Record<PeCase, Record<PeMode, string>> = {
   aime: {
-    raw: '/images/pe-aime-raw.jpg',
-    '3b': '/images/pe-aime-3b.jpg',
-    large: '/images/pe-aime-large.jpg',
+    raw: `${import.meta.env.BASE_URL}images/pe-aime-raw.jpg`,
+    '3b': `${import.meta.env.BASE_URL}images/pe-aime-3b.jpg`,
+    large: `${import.meta.env.BASE_URL}images/pe-aime-large.jpg`,
   },
   rpg: {
-    raw: '/images/pe-rpg-raw.jpg',
-    '3b': '/images/pe-rpg-3b.jpg',
-    large: '/images/pe-rpg-large.jpg',
+    raw: `${import.meta.env.BASE_URL}images/pe-rpg-raw.jpg`,
+    '3b': `${import.meta.env.BASE_URL}images/pe-rpg-3b.jpg`,
+    large: `${import.meta.env.BASE_URL}images/pe-rpg-large.jpg`,
   },
   web: {
-    raw: '/images/pe-web-raw.jpg',
-    '3b': '/images/pe-web-3b.jpg',
-    large: '/images/pe-web-large.jpg',
+    raw: `${import.meta.env.BASE_URL}images/pe-web-raw.jpg`,
+    '3b': `${import.meta.env.BASE_URL}images/pe-web-3b.jpg`,
+    large: `${import.meta.env.BASE_URL}images/pe-web-large.jpg`,
   },
 };
 

--- a/html_output/ernie_image_technical_report/src/modules/ch9-aesthetic.tsx
+++ b/html_output/ernie_image_technical_report/src/modules/ch9-aesthetic.tsx
@@ -172,7 +172,7 @@ export const Ch9AestheticWidget: React.FC<WidgetProps> = ({ chapterId, moduleId 
     {view === 'flow' ? <>
       <div className="aesthetic-flow-grid">
         <figure className="paper-figure" style={{ margin: 0 }}>
-          <img src="/images/swiss-interface.jpg" alt="论文原始 Swiss 两两审美标注界面" style={{ width: '100%', maxHeight: 380, objectFit: 'contain' }} />
+          <img src={`${import.meta.env.BASE_URL}images/swiss-interface.jpg`} alt="论文原始 Swiss 两两审美标注界面" style={{ width: '100%', maxHeight: 380, objectFit: 'contain' }} />
           <figcaption>论文原图：Swiss 两两标注界面。它是流程证据，不是本教程生成的校样。</figcaption>
         </figure>
         <div>
@@ -181,7 +181,7 @@ export const Ch9AestheticWidget: React.FC<WidgetProps> = ({ chapterId, moduleId 
           <div className="step-ctrl" role="radiogroup" aria-label="本轮偏好"><button className={`tiny ${choices[round - 1] === 'left' ? '' : 'ghost'}`} role="radio" aria-checked={choices[round - 1] === 'left'} onClick={() => choose('left')}>{pair[0]} 更美</button><button className={`tiny ${choices[round - 1] === 'right' ? '' : 'ghost'}`} role="radio" aria-checked={choices[round - 1] === 'right'} onClick={() => choose('right')}>{pair[1]} 更美</button></div>
         </div>
       </div>
-      <details style={{ marginTop: 12 }}><summary>查看论文层级预览图</summary><figure className="paper-figure"><img src="/images/tier-preview.png" alt="论文原始审美层级预览图" style={{ width: '100%', maxHeight: 420, objectFit: 'contain' }} /><figcaption>审美层级预览。</figcaption></figure></details>
+      <details style={{ marginTop: 12 }}><summary>查看论文层级预览图</summary><figure className="paper-figure"><img src={`${import.meta.env.BASE_URL}images/tier-preview.png`} alt="论文原始审美层级预览图" style={{ width: '100%', maxHeight: 420, objectFit: 'contain' }} /><figcaption>审美层级预览。</figcaption></figure></details>
     </> : <div className="eria-evaluation-row">
       <canvas id={`cv-${chapterId}-${moduleId}`} ref={canvasRef} width={W} height={H_ERIA} aria-label={`ERIA-1K ${metric} 持出评测流程与四模型结果`} />
       <div className="chip-row" role="radiogroup" aria-label="相关系数">{(['SRCC', 'PLCC'] as Metric[]).map((item) => <button key={item} className={`chip ${metric === item ? 'selected' : ''}`} role="radio" aria-checked={metric === item} onClick={() => selectMetric(item)}>{item}（越高越好）</button>)}</div>


### PR DESCRIPTION
## What changed

- Replaced all 15 root-relative `/images/...` references in the ERNIE-Image tutorial with Vite-aware `import.meta.env.BASE_URL` paths.
- Updated the architecture, prompt-enhancer examples, aesthetic-evaluation figures, and qualitative-result figures.

## Why

The tutorial is deployed below `/PaperSkill/papers/ernie_image_technical_report/`. Root-relative image URLs resolved against `https://reducttech.github.io/images/...` and returned 404 even though the files were present in the tutorial's deployed `images` directory.

## Impact

Images now resolve correctly both in local Vite preview and in the GitHub Pages subdirectory deployment.

## Validation

- `npm run build` passes for the source tutorial.
- `npm run build` passes for `html_output/ernie_image_technical_report`.
- The repository validator reports `ernie_image_technical_report` as valid.
- The repository-wide check is currently blocked only by an unrelated pre-existing missing `paper.json` in `agentic_routing_the_harness_hative_data_flywheel`.
