### PR TITLE
fix: correct Figure 5 asset path

### DIFF
--- a/html_output/starvla_reducing_complexity_in_vision_language_action_systems/src/modules/starvla-revision.tsx
+++ b/html_output/starvla_reducing_complexity_in_vision_language_action_systems/src/modules/starvla-revision.tsx
@@ -146,7 +146,8 @@ export function GeneralistResults(_: WidgetProps) {
 }
 
 export function GeneralistFactors(_: WidgetProps) {
-  return <div className="sv-panel"><figure className="paper-figure"><a href="/images/starvla-figure5.png" target="_blank" rel="noreferrer" aria-label="打开论文 Figure 5 原图"><img src="/images/starvla-figure5.png" alt="论文 Figure 5：VLA 训练中的模型大小与批大小扩展趋势" /></a><figcaption>来源：论文 Figure 5</figcaption></figure><Feedback tone="green"><b>模型规模：</b>2B 到 4B 提升明显，而 4B 到 8B 的进一步增益不足 1%。</Feedback><Feedback tone="blue"><b>批大小：</b>性能随批大小增大持续提升，说明训练多样性是通用设置中的关键因素。</Feedback></div>;
+  const figure5Url = `${import.meta.env.BASE_URL}images/starvla-figure5.png`;
+  return <div className="sv-panel"><figure className="paper-figure"><a href={figure5Url} target="_blank" rel="noreferrer" aria-label="打开论文 Figure 5 原图"><img src={figure5Url} alt="论文 Figure 5：VLA 训练中的模型大小与批大小扩展趋势" /></a><figcaption>来源：论文 Figure 5</figcaption></figure><Feedback tone="green"><b>模型规模：</b>2B 到 4B 提升明显，而 4B 到 8B 的进一步增益不足 1%。</Feedback><Feedback tone="blue"><b>批大小：</b>性能随批大小增大持续提升，说明训练多样性是通用设置中的关键因素。</Feedback></div>;
 }
 
 export function RealWorld(_: WidgetProps) {


### PR DESCRIPTION
## 修复说明

修复 StarVLA-α 教程 §6.3 中论文 Figure 5 在 GitHub Pages 子目录下无法显示的问题。

### 原因

图片使用了根路径：

`/images/starvla-figure5.png`

部署后会错误请求 `https://reducttech.github.io/images/...`。

### 修改

改用 Vite 部署基础路径：

`${import.meta.env.BASE_URL}images/starvla-figure5.png`

该写法可以同时兼容本地运行和 GitHub Pages 多级目录部署。

## 验证

- `npm run build:paper -- starvla_reducing_complexity_in_vision_language_action_systems`：通过
- TypeScript 与 Vite 生产构建：通过
- 模拟 GitHub Pages 子目录访问：页面返回 200
- Figure 5 图片返回 200，类型为 `image/png`
- 本 PR 仅修改 1 个源文件，不修改 `paper.json`、目录结构或其他教程内容