### PR TITLE
Fix ClawGUI paper image paths

### DIFF
--- a/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/components/Figure.tsx
+++ b/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/components/Figure.tsx
@@ -1,4 +1,4 @@
-// Optional paper-figure display. `src` is a path under /public (e.g. "/images/fig1.png")
+// Optional paper-figure display. `src` is a relative path under /public (e.g. "./images/fig1.png")
 // or an absolute URL. Figures are OPTIONAL (per contract.md §7/figures): only render when
 // the generator supplies `src`. UI copy is Simplified Chinese where present.
 

--- a/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/modules/m2a.tsx
+++ b/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/modules/m2a.tsx
@@ -266,7 +266,7 @@ export const M2a: React.FC<WidgetProps> = ({ chapterId, moduleId }) => {
           }}
         >
           <img
-            src="/images/fig1-overview.png"
+            src="./images/fig1-overview.png"
             alt="论文 Figure 1：ClawGUI 框架总览"
             loading="lazy"
             style={{

--- a/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/types.ts
+++ b/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/types.ts
@@ -18,7 +18,7 @@ export interface Meta {
 }
 
 export interface FigureRef {
-  /** Path under public/ (e.g. "/images/fig1.png") or an absolute URL. Optional. */
+  /** Relative path under public/ (e.g. "./images/fig1.png") or an absolute URL. Optional. */
   src: string;
   caption?: string;
   alt?: string;


### PR DESCRIPTION
## 修复内容

ClawGUI 教程中的论文 Figure 1 使用了根相对路径 `/images/fig1-overview.png`。部署到 GitHub Pages 子路径 `PaperSkill/papers/<paper-name>/` 后，该路径会错误解析到域名根目录，导致图片无法加载。

本 PR：

- 将实际图片引用改为 `./images/fig1-overview.png`；
- 同步更新 `FigureRef` 和通用 `Figure` 组件中的路径示例；
- 不修改图片内容、页面结构或交互逻辑。

## 验证

- [x] 不再存在 `/images/...` 根相对论文图片路径
- [x] `paper-skill` 结构验证通过
- [x] `npm run build:paper -- clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents`
- [x] 生产 bundle 保留 `./images/fig1-overview.png`
- [x] PR 仅修改 ClawGUI 项目中的 3 个源码文件
