### PR TITLE
fix: use relative paper image paths

### DIFF
--- a/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/components/Figure.tsx
+++ b/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/components/Figure.tsx
@@ -1,4 +1,4 @@
-// Optional paper-figure display. `src` is a path under /public (e.g. "/images/fig1.png")
+// Optional paper-figure display. `src` is a relative path under /public (e.g. "./images/fig1.png")
 // or an absolute URL. Figures are OPTIONAL (per contract.md §7/figures): only render when
 // the generator supplies `src`. UI copy is Simplified Chinese where present.
 

--- a/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/modules/m2a.tsx
+++ b/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/modules/m2a.tsx
@@ -266,7 +266,7 @@ export const M2a: React.FC<WidgetProps> = ({ chapterId, moduleId }) => {
           }}
         >
           <img
-            src="/images/fig1-overview.png"
+            src="./images/fig1-overview.png"
             alt="论文 Figure 1：ClawGUI 框架总览"
             loading="lazy"
             style={{

--- a/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/types.ts
+++ b/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/types.ts
@@ -18,7 +18,7 @@ export interface Meta {
 }
 
 export interface FigureRef {
-  /** Path under public/ (e.g. "/images/fig1.png") or an absolute URL. Optional. */
+  /** Relative path under public/ (e.g. "./images/fig1.png") or an absolute URL. Optional. */
   src: string;
   caption?: string;
   alt?: string;


### PR DESCRIPTION
## 论文信息

- 论文：
- 目录：`html_output/<paper-name>/`
- 分支：

## 本次工作

- [ ] 新增一个论文教程实现
- [ ] 修改已有论文实现
- [ ] 仅修改了本实现目录和自动生成的 `catalog/papers.json`
- [ ] 已完成至少三项实质性人工修改

## 自检

- [ ] 已运行 `npm run validate`
- [ ] 已运行 `npm run catalog`
- [ ] 已运行 `npm run build:paper -- <paper-name>`
- [ ] 页面交互、移动端布局和资源路径正常
- [ ] 论文事实、公式和实验数字已人工核对
- [ ] 未提交 `node_modules/`、`dist/`、密钥或本地绝对路径
- [ ] 图片与外部素材具有可追溯来源，并记录在项目 `README.md`
- [ ] 所有参与者已知晓姓名或展示名及 GitHub 信息会公开显示并表示同意
## 预览与说明

请附关键页面截图、主要交互说明，以及仍需审核者重点确认的内容。

提交前请阅读 `docs/SUBMISSION.md` 和 `docs/RUBRIC.md`。
