### PR TITLE
Fix HY-Embodied-0.5 image paths on GitHub Pages

### DIFF
--- a/html_output/hy_embodied_0_5/src/data/tutorial.ts
+++ b/html_output/hy_embodied_0_5/src/data/tutorial.ts
@@ -15,11 +15,11 @@ export const tutorial: TutorialData = {
   hero: {
     oldMethod: {
       desc: '通用 VLM 能说出“这是红杯”，却不能直接回答是哪一个、边界在哪里、离我多远，以及从哪里接触。',
-      figure: '/images/kitchen-baseline.png',
+      figure: './images/kitchen-baseline.png',
     },
     newMethod: {
       desc: 'HY-Embodied-0.5 把细粒度感知、具身推理和端侧蒸馏接成闭环，再通过 Action Expert 输出连续机器人动作。',
-      figure: '/images/kitchen-hy-embodied.png',
+      figure: './images/kitchen-hy-embodied.png',
     },
   },
   chapters: [

--- a/html_output/hy_embodied_0_5/src/modules/attention-mask.tsx
+++ b/html_output/hy_embodied_0_5/src/modules/attention-mask.tsx
@@ -31,7 +31,7 @@ function PatchWhy() {
     <div className="patch-why-text old"><span>只按先后读取</span><b>杯口暂时看不到杯身与杯柄</b></div>
     <div className="patch-why-figure">
       <div className="real-cup-patch" role="img" aria-label="写实红色马克杯被切分为 6 乘 8 个图像 Patch，杯口、杯身和杯柄属于同一视觉元素">
-        <img src="/assets/red-mug-patch.png" alt="写实红色马克杯" />
+        <img src="./assets/red-mug-patch.png" alt="写实红色马克杯" />
         <div className="real-patch-grid" aria-hidden="true">
           {Array.from({ length: 48 }, (_, index) => <span key={index} />)}
         </div>


### PR DESCRIPTION
## 问题

HY-Embodied-0.5 部署在 `/PaperSkill/papers/hy_embodied_0_5/` 子路径下，但三张图片使用以 `/` 开头的域名根路径，导致浏览器请求 `https://reducttech.github.io/images/...` 或 `/assets/...` 并返回 404。

## 修复

- 将两张厨房示意图改为 `./images/...`
- 将红杯图片改为 `./assets/...`
- 只修改该教程的 2 个源码文件

## 验证

- [x] `npm run validate`
- [x] `npm run catalog:check`
- [x] `npm run validate:pr -- main`
- [x] `npm run build:paper -- hy_embodied_0_5`
- [x] 构建成功，PR 范围检查通过（2 个文件）
