### PR TITLE
Fix ClawGUI Figure 2 image path

### DIFF
--- a/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/data/tutorial.ts
+++ b/html_output/clawgui_a_unified_framework_for_training_evaluating_and_deploying_gui_agents/src/data/tutorial.ts
@@ -110,7 +110,7 @@ export const tutorial: TutorialData = {
           title: '点亮训练闭环的每一环',
           desc: '任务 → Rollout 管理器 → 虚拟环境 / 真机 → 轨迹 → 奖励管理器 → RL 训练器 → 更新模型，回到环境继续试错。',
           componentId: 'rl-pipeline',
-          figure: '/images/fig2-rl.png',
+          figure: './images/fig2-rl.png',
         },
         {
           kind: 'module',


### PR DESCRIPTION
## 修复内容

ClawGUI 教程第 2.1 节的 Figure 2 路径仍为根相对路径 `/images/fig2-rl.png`。在 GitHub Pages 的 `PaperSkill/papers/<paper-name>/` 子路径部署后，它会请求错误位置并显示破图。

本 PR 仅将教程元数据改为：

```ts
figure: './images/fig2-rl.png'
```

## 根因

此前的 Figure 1 修复只检查了组件和类型文件，没有覆盖 `src/data/tutorial.ts` 中的 `figure` 元数据，因此遗漏了第二张论文原图。

## 验证

- [x] `public/images/fig2-rl.png` 文件存在
- [x] 针对 `figure: '/images/...'` 的回归检查由失败变为通过
- [x] 原始项目 `npm run build` 通过
- [x] 生产 bundle 包含 `./images/fig2-rl.png`
- [x] PR 仅修改 ClawGUI `src/data/tutorial.ts` 一行
