### PR TITLE
Fix deployed image paths for Vision Banana tutorial

### DIFF
--- a/html_output/image_generators_are_generalist_vision_learners/src/modules/decode-reversibility.tsx
+++ b/html_output/image_generators_are_generalist_vision_learners/src/modules/decode-reversibility.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { clamp, easeInOutQuad, lerp, observeCanvas, setupCanvas } from '../lib/canvasKit';
+import { paperImage } from './paper-image';
 import type { WidgetProps } from './registry';
 
 type SampleId = 'cat-pixel' | 'lock-pixel' | 'exit-pixel' | 'background-pixel';
@@ -458,11 +459,11 @@ export const DecodeReversibility: React.FC<WidgetProps> = ({ chapterId, moduleId
       <figure className="paper-evidence-figure">
         <div className="paper-task-evidence-grid">
           <div className="paper-task-evidence-panel">
-            <img src="/images/paper-semantic-input.png" alt="论文图 2：橱窗中猫、门锁和出口标志的输入图像" loading="lazy" />
+            <img src={paperImage('paper-semantic-input.png')} alt="论文图 2：橱窗中猫、门锁和出口标志的输入图像" loading="lazy" />
             <span>输入图像</span>
           </div>
           <div className="paper-task-evidence-panel">
-            <img src="/images/paper-semantic-natural.png" alt="论文图 2：按照提示颜色生成的开放词汇语义分割结果" loading="lazy" />
+            <img src={paperImage('paper-semantic-natural.png')} alt="论文图 2：按照提示颜色生成的开放词汇语义分割结果" loading="lazy" />
             <span>生成的 RGB 语义图</span>
           </div>
         </div>

--- a/html_output/image_generators_are_generalist_vision_learners/src/modules/depth-color-bijection.tsx
+++ b/html_output/image_generators_are_generalist_vision_learners/src/modules/depth-color-bijection.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { clamp, lerp, observeCanvas, setupCanvas } from '../lib/canvasKit';
+import { paperImage } from './paper-image';
 import type { WidgetProps } from './registry';
 
 const MAIN_W = 560;
@@ -314,7 +315,7 @@ export const DepthColorBijection: React.FC<WidgetProps> = ({ chapterId, moduleId
   return (
     <div>
       <figure className="paper-evidence-figure">
-        <img src="/images/paper-depth-in-wild.png" alt="论文图 7 高分辨率局部：金阁寺手机照片、Vision Banana 深度图与 Google 地图测距" loading="lazy" />
+        <img src={paperImage('paper-depth-in-wild.png')} alt="论文图 7 高分辨率局部：金阁寺手机照片、Vision Banana 深度图与 Google 地图测距" loading="lazy" />
         <figcaption>
           <strong>图 7｜真实场景的米制深度检查</strong>
           <span>模型从普通手机照片估计相机到金阁寺约 13.71 米；Google 地图测得约 12.87 米。这个案例提供直观校验，但不能替代六个基准上的定量结果。</span>

--- a/html_output/image_generators_are_generalist_vision_learners/src/modules/instruction-mix.tsx
+++ b/html_output/image_generators_are_generalist_vision_learners/src/modules/instruction-mix.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { clamp, lerp, observeCanvas, setupCanvas } from '../lib/canvasKit';
+import { paperImage } from './paper-image';
 import type { WidgetProps } from './registry';
 
 const W=560,H=250,MW=244,MH=130;
@@ -21,9 +22,9 @@ function drawMain(ctx:CanvasRenderingContext2D,state:MixState){ctx.clearRect(0,0
   ctx.strokeStyle=C.blue;ctx.lineWidth=3;ctx.beginPath();ctx.moveTo(160,122);ctx.lineTo(188,122);ctx.moveTo(328,122);ctx.lineTo(384,122);ctx.stroke();if(state.phase==='preserve')seal(ctx,348,190,'近似保留');}
 
 const retentionExamples:Record<RetentionView,{tab:string;prompt:string;image:string;alt:string;columns:string[];source:string;observation:string}>={
-  'ghost-ship':{tab:'文生图 · 幽灵船',prompt:'一艘幽灵般的船航行在雾气笼罩、月光照耀的海面上。',image:'/images/paper-retention-ghost-ship.png',alt:'幽灵船文生图对比：左侧为 Vision Banana，右侧为 Nano Banana Pro',columns:['Vision Banana','Nano Banana Pro'],source:'论文图 11 · 文生图',observation:'两种模型都保留了幽灵船、雾海与月光等关键语义。'},
-  'yellow-taxi':{tab:'文生图 · 黄色出租车',prompt:'一辆黄色出租车等候在一座现代玻璃建筑外。',image:'/images/paper-retention-yellow-taxi.png',alt:'黄色出租车文生图对比：左侧为 Vision Banana，右侧为 Nano Banana Pro',columns:['Vision Banana','Nano Banana Pro'],source:'论文图 11 · 文生图',observation:'两种模型都生成了现代玻璃建筑外的黄色出租车。'},
-  'red-vehicle':{tab:'图像编辑 · 车辆改红',prompt:'把车辆颜色改成红色。',image:'/images/paper-retention-red-vehicle.png',alt:'车辆改红图像编辑对比：从左到右为原图、Vision Banana 和 Nano Banana Pro',columns:['原图','Vision Banana','Nano Banana Pro'],source:'论文图 12 · 图像编辑',observation:'两种模型都把车辆改为红色，同时保留了森林和露营车的主体结构。'},
+  'ghost-ship':{tab:'文生图 · 幽灵船',prompt:'一艘幽灵般的船航行在雾气笼罩、月光照耀的海面上。',image:paperImage('paper-retention-ghost-ship.png'),alt:'幽灵船文生图对比：左侧为 Vision Banana，右侧为 Nano Banana Pro',columns:['Vision Banana','Nano Banana Pro'],source:'论文图 11 · 文生图',observation:'两种模型都保留了幽灵船、雾海与月光等关键语义。'},
+  'yellow-taxi':{tab:'文生图 · 黄色出租车',prompt:'一辆黄色出租车等候在一座现代玻璃建筑外。',image:paperImage('paper-retention-yellow-taxi.png'),alt:'黄色出租车文生图对比：左侧为 Vision Banana，右侧为 Nano Banana Pro',columns:['Vision Banana','Nano Banana Pro'],source:'论文图 11 · 文生图',observation:'两种模型都生成了现代玻璃建筑外的黄色出租车。'},
+  'red-vehicle':{tab:'图像编辑 · 车辆改红',prompt:'把车辆颜色改成红色。',image:paperImage('paper-retention-red-vehicle.png'),alt:'车辆改红图像编辑对比：从左到右为原图、Vision Banana 和 Nano Banana Pro',columns:['原图','Vision Banana','Nano Banana Pro'],source:'论文图 12 · 图像编辑',observation:'两种模型都把车辆改为红色，同时保留了森林和露营车的主体结构。'},
 };
 
 export const InstructionMix:React.FC<WidgetProps>=({chapterId,moduleId})=>{const compact=compactMode(moduleId);const canvasRef=useRef<HTMLCanvasElement>(null);const [state,setState]=useState<MixState>({phase:'base',sourceFocus:'generation',hasMixed:false,dropletProgress:0});const [retentionView,setRetentionView]=useState<RetentionView>('ghost-ship');

--- a/html_output/image_generators_are_generalist_vision_learners/src/modules/paper-image.ts
+++ b/html_output/image_generators_are_generalist_vision_learners/src/modules/paper-image.ts
@@ -1,0 +1,4 @@
+/** Resolve a paper figure against Vite's deployment base (local or GitHub Pages). */
+export function paperImage(filename: string): string {
+  return `${import.meta.env.BASE_URL}images/${filename}`;
+}

--- a/html_output/image_generators_are_generalist_vision_learners/src/modules/prompt-color.tsx
+++ b/html_output/image_generators_are_generalist_vision_learners/src/modules/prompt-color.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { observeCanvas, setupCanvas } from '../lib/canvasKit';
+import { paperImage } from './paper-image';
 import type { WidgetProps } from './registry';
 
 const MINI_W = 244;
@@ -39,9 +40,9 @@ const TASKS: Record<Task, TaskRecord> = {
   semantic: {
     label: '语义分割',
     figures: [
-      { src: '/images/paper-semantic-input.png', label: '输入图像', alt: '论文图 2：橱窗中的猫' },
-      { src: '/images/paper-semantic-natural.png', label: '自然语言颜色提示', alt: '论文图 2：自然语言颜色提示生成的语义分割结果' },
-      { src: '/images/paper-semantic-structured.png', label: '结构化 RGB 提示', alt: '论文图 2：结构化 RGB 提示生成的语义分割结果' },
+      { src: paperImage('paper-semantic-input.png'), label: '输入图像', alt: '论文图 2：橱窗中的猫' },
+      { src: paperImage('paper-semantic-natural.png'), label: '自然语言颜色提示', alt: '论文图 2：自然语言颜色提示生成的语义分割结果' },
+      { src: paperImage('paper-semantic-structured.png'), label: '结构化 RGB 提示', alt: '论文图 2：结构化 RGB 提示生成的语义分割结果' },
     ],
     figureNumber: '图 2',
     promptExamples: [
@@ -73,9 +74,9 @@ const TASKS: Record<Task, TaskRecord> = {
   instance: {
     label: '实例分割',
     figures: [
-      { src: '/images/paper-instance-input.png', label: '输入图像', alt: '论文图 3：砂锅与牛肉拼盘的输入图像' },
-      { src: '/images/paper-instance-prompt-a.png', label: '提示：每瓣大蒜', alt: '论文图 3：大蒜实例被分别着色' },
-      { src: '/images/paper-instance-prompt-b.png', label: '提示：每块牛肉', alt: '论文图 3：牛肉实例被分别着色' },
+      { src: paperImage('paper-instance-input.png'), label: '输入图像', alt: '论文图 3：砂锅与牛肉拼盘的输入图像' },
+      { src: paperImage('paper-instance-prompt-a.png'), label: '提示：每瓣大蒜', alt: '论文图 3：大蒜实例被分别着色' },
+      { src: paperImage('paper-instance-prompt-b.png'), label: '提示：每块牛肉', alt: '论文图 3：牛肉实例被分别着色' },
     ],
     figureNumber: '图 3',
     promptExamples: [
@@ -110,8 +111,8 @@ const TASKS: Record<Task, TaskRecord> = {
   referring: {
     label: '指代表达分割',
     figures: [
-      { src: '/images/paper-referring-input.png', label: '输入图像', alt: '论文图 4：广场上的两名男子' },
-      { src: '/images/paper-referring-output.png', label: '“穿粉色 T 恤的男子”', alt: '论文图 4：自由文本指代分割输出' },
+      { src: paperImage('paper-referring-input.png'), label: '输入图像', alt: '论文图 4：广场上的两名男子' },
+      { src: paperImage('paper-referring-output.png'), label: '“穿粉色 T 恤的男子”', alt: '论文图 4：自由文本指代分割输出' },
     ],
     figureNumber: '图 4',
     promptExamples: [

--- a/html_output/image_generators_are_generalist_vision_learners/src/modules/surface-normal-encoding.tsx
+++ b/html_output/image_generators_are_generalist_vision_learners/src/modules/surface-normal-encoding.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { clamp, observeCanvas, setupCanvas } from '../lib/canvasKit';
+import { paperImage } from './paper-image';
 import type { WidgetProps } from './registry';
 
 const W = 560;
@@ -380,7 +381,7 @@ export const SurfaceNormalEncoding: React.FC<WidgetProps> = ({ chapterId, module
   return (
     <div>
       <figure className="paper-evidence-figure">
-        <img src="/images/paper-normal-cat.png" alt="论文图 8 高分辨率局部：输入猫咪、Lotus-2 法线图与 Vision Banana 法线图" loading="lazy" />
+        <img src={paperImage('paper-normal-cat.png')} alt="论文图 8 高分辨率局部：输入猫咪、Lotus-2 法线图与 Vision Banana 法线图" loading="lazy" />
         <figcaption>
           <strong>图 8｜表面法线的三列对照</strong>
           <span>从左到右为输入、Lotus-2 和 Vision Banana。局部裁切保留猫毛、树皮和草叶等细节，避免整页复合图缩小后无法辨认。</span>


### PR DESCRIPTION
## 修复内容

- 将论文图片引用从站点根路径改为基于 Vite BASE_URL 的部署路径
- 覆盖可解码 RGB、三类 2D 任务、深度、表面法线与生成能力保留模块
- 保持本地开发与 GitHub Pages 子目录部署兼容

## 验证

- 
pm run build 通过
- 仓库根目录 
pm run validate 通过
- 13 个运行时图片引用均能对应到 public/images 中的文件