### PR TITLE
Fix image paths for GitHub Pages

### DIFF
--- a/html_output/asymmetric_flow_models/src/modules/final-performance-evidence.tsx
+++ b/html_output/asymmetric_flow_models/src/modules/final-performance-evidence.tsx
@@ -99,7 +99,7 @@ export const FinalPerformanceEvidence: React.FC<WidgetProps> = () => {
           {FILM_MODELS.map((model) => (
             <figure key={`${prompt}-${model.key}`} className={model.key === 'asym' ? 'active' : ''}>
               {/* Source: AsymFlow paper Fig. 7, page 8. */}
-              <img src={`/images/experiments/fig7-${prompt}-${model.key}.png`} alt={`${PROMPTS.find((item) => item.key === prompt)?.label}: ${model.label}`} />
+              <img src={`${import.meta.env.BASE_URL}images/experiments/fig7-${prompt}-${model.key}.png`} alt={`${PROMPTS.find((item) => item.key === prompt)?.label}: ${model.label}`} />
               <figcaption><b>{model.label}</b></figcaption>
             </figure>
           ))}

--- a/html_output/asymmetric_flow_models/src/modules/finetuning-ablation-evidence.tsx
+++ b/html_output/asymmetric_flow_models/src/modules/finetuning-ablation-evidence.tsx
@@ -163,7 +163,7 @@ export const FinetuningAblationEvidence: React.FC<WidgetProps> = () => {
               {active.asset ? (
                 <img
                   key={active.asset}
-                  src={`/images/experiments/fig8-eyes-${active.asset}.png`}
+                  src={`${import.meta.env.BASE_URL}images/experiments/fig8-eyes-${active.asset}.png`}
                   alt={`Figure 8 crop: ${active.label}`}
                 />
               ) : (

--- a/html_output/asymmetric_flow_models/src/modules/rank-evidence-workspace.tsx
+++ b/html_output/asymmetric_flow_models/src/modules/rank-evidence-workspace.tsx
@@ -122,7 +122,7 @@ export const RankEvidenceWorkspace: React.FC<WidgetProps> = () => {
         <section className="af-compact-evidence optimization">
           <header><div><h3>训练效率</h3></div><small>Fig. 6</small></header>
           {/* Source: AsymFlow paper Fig. 6, page 7. */}
-          <img className="af-figure6-image" src="/images/experiments/figure6-convergence.png" alt="Figure 6: AsymFlow and JiT convergence speed comparison" />
+          <img className="af-figure6-image" src={`${import.meta.env.BASE_URL}images/experiments/figure6-convergence.png`} alt="Figure 6: AsymFlow and JiT convergence speed comparison" />
           <p className="af-evidence-statement">Comparable FID，约快 40%。</p>
         </section>
 


### PR DESCRIPTION
## 论文信息

- 论文：
- 目录：`html_output/<paper-name>/`
- 分支：

## 本次工作

- [ ] 新增一个论文教程实现
- [ ] 修改已有论文实现
- [ ] 仅修改了本实现目录和自动生成的 `catalog/papers.json`
- [ ] 已完成至少三项实质性人工修改

## 自检

- [ ] 已运行 `npm run validate`
- [ ] 已运行 `npm run catalog`
- [ ] 已运行 `npm run build:paper -- <paper-name>`
- [ ] 页面交互、移动端布局和资源路径正常
- [ ] 论文事实、公式和实验数字已人工核对
- [ ] 未提交 `node_modules/`、`dist/`、密钥或本地绝对路径
- [ ] 图片与外部素材具有可追溯来源，并记录在项目 `README.md`
- [ ] 所有参与者已知晓姓名或展示名及 GitHub 信息会公开显示并表示同意
## 预览与说明

请附关键页面截图、主要交互说明，以及仍需审核者重点确认的内容。

提交前请阅读 `docs/SUBMISSION.md` 和 `docs/RUBRIC.md`。
